### PR TITLE
catch error when we get from the network less data than we expect

### DIFF
--- a/lib/data_input_stream.js
+++ b/lib/data_input_stream.js
@@ -48,8 +48,13 @@ DataInputStream.prototype.readFields = function (fields, callback, startIndex, d
     var field = fields[index];
     var nextIndex = index + 1;
 
-    var value = self[field.method]();
-    debug('readFields: %s index %d, name: %s, got %s, data %j, socket total read bytes: %d', 
+    var value = null;
+    try {
+        value = self[field.method]();
+    } catch (e) {
+        self.in.emit("error", e);
+    }
+    debug('readFields: %s index %d, name: %s, got %s, data %j, socket total read bytes: %d',
       field.method, index, field.name, value, data, self.in.bytesRead);
     if (value === null) {
       // TODO: listeners too much


### PR DESCRIPTION
On failure of the network we may come less data than we expect. When we are reading more bytes from the buffer may raise uncaught exception. This commit is converted an exception to error event.
