### PR TITLE
bug fix: Error parsing column qualifiers that contain a colon.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -382,8 +382,10 @@ Client.prototype.getRow = function (tableName, row, columns, callback) {
   }
   if (Array.isArray(columns) && columns.length > 0) {
     for (var i = 0; i < columns.length; i++) {
-      var col = columns[i].split(':');
-      get.addColumn(col[0], col[1]);
+      var col = columns[i];
+      var p = col.indexOf(':');
+      p = (p >= 0) ? p : col.length;
+      get.addColumn(col.substr(0, p), col.substr(p+1));
     }
   }
   this.get(tableName, get, function (err, result) {


### PR DESCRIPTION
column qualifiers like  'cf:qualifier:has:colons' are not handled properly by getRow method