### PR TITLE
fix: can't pass test because some incompatible code in mocha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 *.out
 *.pid
 *.gz
+*.sh
 
 pids
 logs

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Asynchronous HBase client for Node.js, **pure JavaScript** implementation.
 
 ## Support HBase Server Versions
 
-* [√] 0.94.x
-    * [√] 0.94.0
-    * [√] 0.94.16
+* [x] 0.94.x
+    * [x] 0.94.0
+    * [x] 0.94.16
 * [ ] 0.96.x
 * [ ] 0.98.x
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "interceptor": "0.1.4",
     "jshint": "*",
     "mm": "~0.2.1",
-    "mocha": "*",
+    "mocha": "^3.5.0",
     "moment": "*",
     "pedding": "~1.0.0",
     "should": "3",


### PR DESCRIPTION
mocha 4.x will result the CI (including run test locally) like below:

https://travis-ci.org/XadillaX/node-hbase-client/builds/305140323

<details>
<pre>
...

  test/writable_utils.test.js
    writeVLong() and readVLong()
      ✓ should convert Long to bytes
  70 passing (6s)
  8 pending
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
</pre>
</details>

<p></p>

To be more clearly, when it under mocha 4.x, the process won't terminated after all test cases finished.

So I downgrade mocha back to the last [succeeded build](https://travis-ci.org/alibaba/node-hbase-client/jobs/281786337#L996) version, that is ^3.5.0.